### PR TITLE
Fix PostgreSQL array scanning error

### DIFF
--- a/internal/database/postgres/reader.go
+++ b/internal/database/postgres/reader.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"sync"
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 	"github.com/nechja/schemalyzer/pkg/models"
 )
 
@@ -366,7 +366,7 @@ func (r *PostgresReader) getIndexes(ctx context.Context, schemaName, tableName s
 		var index models.Index
 		var columnNames []string
 		
-		if err := rows.Scan(&index.Name, &index.IsUnique, &index.Type, &columnNames); err != nil {
+		if err := rows.Scan(&index.Name, &index.IsUnique, &index.Type, pq.Array(&columnNames)); err != nil {
 			return nil, err
 		}
 		


### PR DESCRIPTION
Fixes #1 

This pull request makes minor improvements to the way PostgreSQL array data is handled when scanning database rows. The most notable change is the use of `pq.Array` to correctly scan array fields from the database.

Database handling improvements:

* Updated the `rows.Scan` call in `getIndexes` to use `pq.Array` for scanning array fields, ensuring correct handling of PostgreSQL array types.
* Changed the import of `github.com/lib/pq` from a blank import to a standard import, as its exported functionality (`pq.Array`) is now being used.

Tested with PostgreSQL dvdrental database