### PR TITLE
Feature/schema statistics and samples

### DIFF
--- a/cmd/schemalyzer/commands/common.go
+++ b/cmd/schemalyzer/commands/common.go
@@ -1,8 +1,11 @@
 package commands
 
 import (
+	"context"
 	"fmt"
-	
+	"os"
+	"time"
+
 	"github.com/nechja/schemalyzer/internal/database"
 	"github.com/nechja/schemalyzer/internal/database/mysql"
 	"github.com/nechja/schemalyzer/internal/database/oracle"
@@ -37,4 +40,60 @@ func filterTablesOnly(schema *models.Schema) *models.Schema {
 		Triggers:   []models.Trigger{},
 	}
 	return filtered
+}
+
+// collectStatistics collects additional statistics for the schema
+func collectStatistics(ctx context.Context, reader database.SchemaReader, schema *models.Schema) error {
+	// Add overall statistics if requested
+	if withStats {
+		totalColumns := 0
+		for _, table := range schema.Tables {
+			totalColumns += len(table.Columns)
+		}
+
+		schema.Stats = &models.SchemaStats{
+			TableCount:   len(schema.Tables),
+			ViewCount:    len(schema.Views),
+			TotalColumns: totalColumns,
+			IndexCount:   len(schema.Indexes),
+			GeneratedAt:  time.Now(),
+		}
+	}
+
+	// Collect row counts and samples if requested
+	if withRowCount || withSamples {
+		statsReader, ok := reader.(database.StatisticsReader)
+		if !ok {
+			return fmt.Errorf("statistics not supported for this database type")
+		}
+
+		for i := range schema.Tables {
+			table := &schema.Tables[i]
+
+			// Get row count
+			if withRowCount {
+				count, err := statsReader.GetTableRowCount(ctx, schema.Name, table.Name)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to get row count for table %s: %v\n", table.Name, err)
+				} else {
+					table.RowCount = &count
+				}
+			}
+
+			// Get sample values
+			if withSamples {
+				for j := range table.Columns {
+					column := &table.Columns[j]
+					samples, err := statsReader.GetColumnSamples(ctx, schema.Name, table.Name, column.Name, sampleSize)
+					if err != nil {
+						// Silently skip columns where we can't get samples
+						continue
+					}
+					column.Samples = samples
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/cmd/schemalyzer/commands/compare.go
+++ b/cmd/schemalyzer/commands/compare.go
@@ -22,6 +22,10 @@ var (
 	outputFile   string
 	ignorePatterns []string
 	tablesOnly   bool
+	withStats    bool
+	withRowCount bool
+	withSamples  bool
+	sampleSize   int
 )
 
 var compareCmd = &cobra.Command{

--- a/cmd/schemalyzer/commands/export.go
+++ b/cmd/schemalyzer/commands/export.go
@@ -22,6 +22,10 @@ func init() {
 	exportCmd.Flags().StringVar(&sourceSchema, "schema", "", "Schema name to export")
 	exportCmd.Flags().StringVar(&outputFile, "output", "", "Output file path (required)")
 	exportCmd.Flags().BoolVar(&tablesOnly, "tables-only", false, "Export only tables and their structure (no procedures, functions, triggers)")
+	exportCmd.Flags().BoolVar(&withStats, "with-stats", false, "Include schema statistics (table count, column count, etc.)")
+	exportCmd.Flags().BoolVar(&withRowCount, "with-row-count", false, "Include row counts for each table")
+	exportCmd.Flags().BoolVar(&withSamples, "with-samples", false, "Include sample values for each column")
+	exportCmd.Flags().IntVar(&sampleSize, "sample-size", 3, "Number of sample values to collect per column (default: 3)")
 	_ = exportCmd.MarkFlagRequired("type")
 	_ = exportCmd.MarkFlagRequired("conn")
 	_ = exportCmd.MarkFlagRequired("schema")
@@ -30,37 +34,45 @@ func init() {
 
 func runExport(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
-	
+
 	// Create reader
 	reader, err := createReader(sourceType)
 	if err != nil {
 		return fmt.Errorf("failed to create reader: %w", err)
 	}
 	defer reader.Close()
-	
+
 	// Connect
 	if err := reader.Connect(ctx, sourceConn); err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
-	
+
 	// Get schema
 	fmt.Fprintf(os.Stderr, "Reading schema: %s\n", sourceSchema)
 	schemaData, err := reader.GetSchema(ctx, sourceSchema)
 	if err != nil {
 		return fmt.Errorf("failed to read schema: %w", err)
 	}
-	
+
 	// Filter schema if --tables-only is set
 	if tablesOnly {
 		schemaData = filterTablesOnly(schemaData)
 	}
-	
+
+	// Collect statistics if requested
+	if withStats || withRowCount || withSamples {
+		if err := collectStatistics(ctx, reader, schemaData); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to collect some statistics: %v\n", err)
+			// Continue even if statistics collection fails
+		}
+	}
+
 	// Save to file
 	loader := schema.NewLoader()
 	if err := loader.SaveToFile(schemaData, outputFile); err != nil {
 		return fmt.Errorf("failed to save schema: %w", err)
 	}
-	
+
 	fmt.Fprintf(os.Stderr, "Schema exported to: %s\n", outputFile)
 	return nil
 }

--- a/internal/database/interfaces.go
+++ b/internal/database/interfaces.go
@@ -19,3 +19,8 @@ type SchemaComparer interface {
 type OutputFormatter interface {
 	Format(result *models.ComparisonResult) ([]byte, error)
 }
+
+type StatisticsReader interface {
+	GetTableRowCount(ctx context.Context, schemaName, tableName string) (int64, error)
+	GetColumnSamples(ctx context.Context, schemaName, tableName, columnName string, limit int) ([]string, error)
+}

--- a/internal/database/mysql/reader.go
+++ b/internal/database/mysql/reader.go
@@ -618,3 +618,47 @@ func (r *MySQLReader) Close() error {
 	}
 	return nil
 }
+
+// GetTableRowCount returns the row count for a specific table
+func (r *MySQLReader) GetTableRowCount(ctx context.Context, schemaName, tableName string) (int64, error) {
+	var count int64
+
+	// MySQL uses backticks for identifier quoting
+	query := fmt.Sprintf("SELECT COUNT(*) FROM `%s`.`%s`", schemaName, tableName)
+
+	err := r.db.QueryRowContext(ctx, query).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get row count: %w", err)
+	}
+
+	return count, nil
+}
+
+// GetColumnSamples returns sample values for a specific column
+func (r *MySQLReader) GetColumnSamples(ctx context.Context, schemaName, tableName, columnName string, limit int) ([]string, error) {
+	// Build query to get distinct sample values
+	// Convert to CHAR to ensure we can get string representation
+	query := fmt.Sprintf(`
+		SELECT DISTINCT CAST(`+"`%s`"+` AS CHAR)
+		FROM `+"`%s`.`%s`"+`
+		WHERE `+"`%s`"+` IS NOT NULL
+		LIMIT %d
+	`, columnName, schemaName, tableName, columnName, limit)
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get column samples: %w", err)
+	}
+	defer rows.Close()
+
+	var samples []string
+	for rows.Next() {
+		var value string
+		if err := rows.Scan(&value); err != nil {
+			continue // Skip values that can't be converted to string
+		}
+		samples = append(samples, value)
+	}
+
+	return samples, rows.Err()
+}

--- a/pkg/models/schema.go
+++ b/pkg/models/schema.go
@@ -20,6 +20,7 @@ type Schema struct {
 	Procedures   []Procedure
 	Functions    []Function
 	Triggers     []Trigger
+	Stats        *SchemaStats `yaml:"stats,omitempty" json:"stats,omitempty"`
 }
 
 type Table struct {
@@ -29,6 +30,7 @@ type Table struct {
 	Constraints []Constraint
 	Indexes     []Index
 	Comment     string
+	RowCount    *int64 `yaml:"row_count,omitempty" json:"row_count,omitempty"`
 }
 
 type Column struct {
@@ -40,6 +42,7 @@ type Column struct {
 	IsUnique     bool
 	Comment      string
 	Position     int
+	Samples      []string `yaml:"samples,omitempty" json:"samples,omitempty"`
 }
 
 type Constraint struct {
@@ -164,4 +167,12 @@ type ComparisonResult struct {
 	ComparisonTime    time.Time
 	SourceDatabase    string
 	TargetDatabase    string
+}
+
+type SchemaStats struct {
+	TableCount    int       `yaml:"table_count" json:"table_count"`
+	ViewCount     int       `yaml:"view_count" json:"view_count"`
+	TotalColumns  int       `yaml:"total_columns" json:"total_columns"`
+	IndexCount    int       `yaml:"index_count" json:"index_count"`
+	GeneratedAt   time.Time `yaml:"generated_at" json:"generated_at"`
 }


### PR DESCRIPTION
This pull request introduces new schema statistics and data sampling features to the export and comparison commands, enhancing the ability to analyze and understand database schemas. The main changes include support for collecting table and column statistics (such as row counts and sample values), updates to the schema data model, and implementations for MySQL, PostgreSQL, and Oracle backends.

**New statistics and sampling features:**

* Added command-line flags to enable collection of schema statistics, row counts, and column sample values, including a configurable sample size, in both the export and compare commands (`cmd/schemalyzer/commands/export.go`, `cmd/schemalyzer/commands/compare.go`). [[1]](diffhunk://#diff-4dfc4a282c7fff0d6139f113691d930b9c96ff035770aba7534d3233edabf69cR25-R28) [[2]](diffhunk://#diff-e2768978f2c859a426307a9a57dde9b796046410484813d32557cf072fe6c538R25-R28)
* Implemented the `collectStatistics` function to aggregate statistics (table count, view count, total columns, index count, row counts, and column samples) when exporting or comparing schemas (`cmd/schemalyzer/commands/common.go`). [[1]](diffhunk://#diff-ade5531b498e14042a49703f8d9736176b95f53c574adc5e1f7077633238b216R44-R99) [[2]](diffhunk://#diff-ade5531b498e14042a49703f8d9736176b95f53c574adc5e1f7077633238b216R4-R7) [[3]](diffhunk://#diff-4dfc4a282c7fff0d6139f113691d930b9c96ff035770aba7534d3233edabf69cR62-R69)

**Schema model enhancements:**

* Extended the `Schema`, `Table`, and `Column` structs to include fields for overall statistics (`Stats`), per-table row counts (`RowCount`), and per-column sample values (`Samples`). Added a new `SchemaStats` struct to represent aggregated statistics (`pkg/models/schema.go`). [[1]](diffhunk://#diff-39282ce5d47b99bb23bdb9b61ed00cdebe81fe18f809838d0144ff1cf0a29827R23) [[2]](diffhunk://#diff-39282ce5d47b99bb23bdb9b61ed00cdebe81fe18f809838d0144ff1cf0a29827R33) [[3]](diffhunk://#diff-39282ce5d47b99bb23bdb9b61ed00cdebe81fe18f809838d0144ff1cf0a29827R45) [[4]](diffhunk://#diff-39282ce5d47b99bb23bdb9b61ed00cdebe81fe18f809838d0144ff1cf0a29827R171-R178)

**Backend support for statistics:**

* Defined a new `StatisticsReader` interface for retrieving row counts and column samples, and implemented it for MySQL, PostgreSQL, and Oracle readers, including safe identifier quoting and value conversion for each backend (`internal/database/interfaces.go`, `internal/database/mysql/reader.go`, `internal/database/postgres/reader.go`, `internal/database/oracle/reader.go`). [[1]](diffhunk://#diff-14d84fed444fe06a6b7a51bc167cae7c9b2b246807fda9aecd163b2e06769b01R22-R26) [[2]](diffhunk://#diff-48052028a9dd22ed8ba016543d30df17fceed3efdc14006690ef242faed17171R621-R664) [[3]](diffhunk://#diff-21187d734f13a9a59e92bc613c5e085ad4cbc971fa38735284d4a59a2926fd8eR576-R625) [[4]](diffhunk://#diff-43847c321a7c94733aabdc87186b0da8aed868075a7c579e266b0b2c7eac223dR708-R758)