### PR TITLE
Track MySQL auto-increment columns in comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ Flags:
 
 Foreign key differences include ON UPDATE/ON DELETE actions (e.g., `CASCADE`, `SET NULL`), ensuring JSON/YAML outputs expose cascading behavior changes alongside the constraint metadata.
 
+MySQL comparisons now track auto-increment attributes on columns in addition to data type, nullability, and defaults. Changes are visible in JSON/YAML outputs and result in `Column` differences.
+
 ### `validate` - Validate schema against a golden file
 
 Perfect for CI/CD pipelines. Returns exit code 0 if schemas match, 2 if they differ.

--- a/internal/compare/comparer.go
+++ b/internal/compare/comparer.go
@@ -213,6 +213,9 @@ func (c *Comparer) columnsEqual(source, target *models.Column) bool {
 	if source.IsUnique != target.IsUnique {
 		return false
 	}
+	if source.IsAutoIncrement != target.IsAutoIncrement {
+		return false
+	}
 	if source.Comment != target.Comment {
 		return false
 	}

--- a/internal/compare/comparer_test.go
+++ b/internal/compare/comparer_test.go
@@ -148,6 +148,43 @@ func TestComparer_Compare_ModifiedColumn(t *testing.T) {
 	assert.Equal(t, "users.name", result.Differences[0].ObjectName)
 }
 
+func TestComparer_Compare_AutoIncrementChange(t *testing.T) {
+	comparer := NewComparer()
+
+	schema1 := &models.Schema{
+		Name:         "test",
+		DatabaseType: models.MySQL,
+		Tables: []models.Table{
+			{
+				Name: "users",
+				Columns: []models.Column{
+					{Name: "id", DataType: "int", IsPrimaryKey: true, IsAutoIncrement: true},
+				},
+			},
+		},
+	}
+
+	schema2 := &models.Schema{
+		Name:         "test",
+		DatabaseType: models.MySQL,
+		Tables: []models.Table{
+			{
+				Name: "users",
+				Columns: []models.Column{
+					{Name: "id", DataType: "int", IsPrimaryKey: true, IsAutoIncrement: false},
+				},
+			},
+		},
+	}
+
+	result := comparer.Compare(schema1, schema2)
+	if assert.Equal(t, 1, len(result.Differences)) {
+		assert.Equal(t, models.Modified, result.Differences[0].Type)
+		assert.Equal(t, "Column", result.Differences[0].ObjectType)
+		assert.Equal(t, "users.id", result.Differences[0].ObjectName)
+	}
+}
+
 func TestComparer_Compare_AddedConstraint(t *testing.T) {
 	comparer := NewComparer()
 

--- a/internal/fingerprint/hasher.go
+++ b/internal/fingerprint/hasher.go
@@ -97,6 +97,10 @@ func (h *Hasher) normalizeColumns(columns []models.Column) []map[string]interfac
 			normalized["default"] = *col.DefaultValue
 		}
 
+		if col.IsAutoIncrement {
+			normalized["auto_increment"] = true
+		}
+
 		if h.includeComments && col.Comment != "" {
 			normalized["comment"] = col.Comment
 		}

--- a/pkg/models/schema.go
+++ b/pkg/models/schema.go
@@ -34,15 +34,16 @@ type Table struct {
 }
 
 type Column struct {
-	Name         string
-	DataType     string
-	IsNullable   bool
-	DefaultValue *string
-	IsPrimaryKey bool
-	IsUnique     bool
-	Comment      string
-	Position     int
-	Samples      []string `yaml:"samples,omitempty" json:"samples,omitempty"`
+	Name            string
+	DataType        string
+	IsNullable      bool
+	DefaultValue    *string
+	IsPrimaryKey    bool
+	IsUnique        bool
+	IsAutoIncrement bool `yaml:"auto_increment,omitempty" json:"auto_increment,omitempty"`
+	Comment         string
+	Position        int
+	Samples         []string `yaml:"samples,omitempty" json:"samples,omitempty"`
 }
 
 type Constraint struct {


### PR DESCRIPTION
Adds MySQL AUTO_INCREMENT column tracking to schema comparisons.

Rebased from PR #8 to resolve conflicts with PR #7.

Fixes #6

Credit: @trx222 @teerix