### PR TITLE
fix: clarity is always a winner

### DIFF
--- a/cmd/schemalyzer/commands/compare.go
+++ b/cmd/schemalyzer/commands/compare.go
@@ -137,10 +137,12 @@ func runCompare(cmd *cobra.Command, args []string) error {
 		fmt.Print(string(outputData))
 	}
 	
-	// Return error with exit code if differences found
+	// Exit with code 2 if differences found (informational, not an error)
 	if len(result.Differences) > 0 {
-		return NewExitErrorf(ExitCodeMismatch, "found %d differences between schemas", len(result.Differences))
+		fmt.Fprintf(os.Stderr, "Found %d differences between schemas\n", len(result.Differences))
+		os.Exit(ExitCodeMismatch)
 	}
-	
+
+	fmt.Fprintf(os.Stderr, "Schemas are identical\n")
 	return nil
 }

--- a/cmd/schemalyzer/commands/compare_fingerprints.go
+++ b/cmd/schemalyzer/commands/compare_fingerprints.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/nechja/schemalyzer/internal/fingerprint"
@@ -112,12 +113,12 @@ func runCompareFingerprints(cmd *cobra.Command, args []string) error {
 			fmt.Println("\nRun 'schemalyzer compare' for detailed differences")
 		}
 	}
-	
+
 	if !match {
-		// Return error to trigger exit code 2
-		return NewExitError(ExitCodeMismatch, "schemas do not match")
+		// Exit with code 2 if schemas don't match
+		os.Exit(ExitCodeMismatch)
 	}
-	
+
 	return nil
 }
 

--- a/cmd/schemalyzer/commands/validate.go
+++ b/cmd/schemalyzer/commands/validate.go
@@ -82,8 +82,8 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	// In pipeline mode, only output if there are differences
 	if pipelineMode {
 		if len(result.Differences) > 0 {
-			fmt.Fprintf(os.Stderr, "FAIL: Schema validation failed - %d differences found\n", len(result.Differences))
-			return NewExitErrorf(ExitCodeMismatch, "validation failed with %d differences", len(result.Differences))
+			fmt.Fprintf(os.Stderr, "Validation failed: %d differences found\n", len(result.Differences))
+			os.Exit(ExitCodeMismatch)
 		}
 		// Success - no output
 		return nil
@@ -138,7 +138,8 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Println()
 	}
-	
-	// Return error with exit code for differences
-	return NewExitErrorf(ExitCodeMismatch, "validation failed with %d differences", len(result.Differences))
+
+	// Exit with code 2 for differences (informational, not an error)
+	os.Exit(ExitCodeMismatch)
+	return nil
 }


### PR DESCRIPTION
Solves #5  "Misleading error output" as the rest of five was solved in #8 

Tested on all local docker containers.